### PR TITLE
Tests game engine reset and game world

### DIFF
--- a/tests/test_gameengine.py
+++ b/tests/test_gameengine.py
@@ -1,0 +1,45 @@
+import pygame.mouse
+import pytest
+
+import constants
+from src.userinterface import UserInterface
+from src.gamestate import GameState
+from src.gameworld import GameWorld
+from src.playerstate import PlayerState
+from src.gameengine import GameEngine
+from src.gamestates import GameStates
+
+
+@pytest.fixture
+def starting_ge():
+    ui = UserInterface()
+    gs = GameState()
+    gw = GameWorld()
+    ps = PlayerState()
+    ge = GameEngine(ps, gw, gs, ui)
+    return ge
+
+
+def test_gamestate_reset(starting_ge):
+    # modify test once multiple levels have been added
+    # self.gw = GameWorld(Levels.LevelName.SMASHCORE_?)
+    starting_ge.fps = 500 # any number is fine as long as it isn't an initial FPS
+    starting_ge.gs.cur_state = GameStates.GAME_OVER
+    starting_ge.ps.lives = 0
+    starting_ge.ps.score = 90
+    pygame.mouse.set_visible(True)
+    starting_ge.reset_game()
+    assert starting_ge.fps == constants.INITIAL_FPS_SIMPLE
+    # enums should be compared by identity
+    # assert starting_ge.gs.cur_state is GameStates.SPLASH
+    # but it isn't working so comparing by name
+    assert starting_ge.gs.cur_state.name is GameStates.SPLASH.name
+    assert starting_ge.ps.lives == constants.START_LIVES
+    assert starting_ge.ps.score == 0
+    assert not pygame.mouse.get_visible()
+
+
+
+
+
+

--- a/tests/test_gameworld.py
+++ b/tests/test_gameworld.py
@@ -1,0 +1,18 @@
+from gameworld import GameWorld
+from src.ball import Ball
+from src.paddle import Paddle
+from src.brick import Brick
+
+
+def test_gameworld_init():
+    """
+    Test the gameworld has a ball, paddle, and at least one brick
+    :return:
+    """
+    gw = GameWorld()
+    ball_found = any(isinstance(obj, Ball) for obj in gw.world_objects)
+    paddle_found = any(isinstance(obj, Paddle) for obj in gw.world_objects)
+    brick_found = any(isinstance(obj, Brick) for obj in gw.world_objects)
+    assert ball_found
+    assert paddle_found
+    assert brick_found


### PR DESCRIPTION
Test for game world ensures paddle, ball, and at least one brick were created in the game world
Test for game engine reset tests that a game resets to the initial values.