### PR TITLE
190 add spawning logic for custom brick assets   ver 1.1

### DIFF
--- a/src/assets.py
+++ b/src/assets.py
@@ -33,7 +33,7 @@ BRK_YELLOW_IMG, BRK_BLUE_IMG, BRK_GREEN_IMG = None, None, None
 BRK_RED_IMG, BRK_PINK_IMG, BRK_ORANGE_IMG, = None, None, None
 BRK_LTBLUE_IMG, BRK_PURPLE_IMG, BRK_TEAL_IMG = None, None, None
 BRK_LAVENDER_IMG = None
-
+BRICK_COLORS = []
 
 def load_assets():
     """
@@ -43,7 +43,7 @@ def load_assets():
     global BACKGROUND_IMG, BALL_IMG, PADDLE_IMG
     global BRK_YELLOW_IMG, BRK_BLUE_IMG, BRK_GREEN_IMG, BRK_RED_IMG
     global BRK_PINK_IMG, BRK_ORANGE_IMG, BRK_LTBLUE_IMG, BRK_PURPLE_IMG
-    global BRK_TEAL_IMG, BRK_LAVENDER_IMG
+    global BRK_TEAL_IMG, BRK_LAVENDER_IMG, BRICK_COLORS
     BACKGROUND_IMG = pygame.image.load(os.path.join(ART_DIR, BACKGROUND_FILENAME))
     BRK_YELLOW_IMG = pygame.image.load(os.path.join(ART_DIR, BRK_YELLOW_FILENAME))
     BRK_BLUE_IMG = pygame.image.load(os.path.join(ART_DIR, BRK_BLUE_FILENAME))
@@ -57,3 +57,6 @@ def load_assets():
     BRK_LAVENDER_IMG = pygame.image.load(os.path.join(ART_DIR, BRK_LAVENDER_FILENAME))
     BALL_IMG = pygame.image.load(os.path.join(ART_DIR, BALL_FILENAME))
     PADDLE_IMG = pygame.image.load(os.path.join(ART_DIR, PADDLE_FILENAME))
+
+    BRICK_COLORS = [BRK_YELLOW_IMG, BRK_BLUE_IMG, BRK_GREEN_IMG, BRK_RED_IMG, BRK_PINK_IMG, BRK_ORANGE_IMG,
+                    BRK_LTBLUE_IMG, BRK_PURPLE_IMG, BRK_TEAL_IMG, BRK_LAVENDER_IMG]

--- a/src/ball.py
+++ b/src/ball.py
@@ -175,9 +175,9 @@ class Ball(WorldObject, pygame.sprite.Sprite):
         :return:
         """
         # SIMPLE_1 motion model defaults
-        self.rect.center = self.commanded_pos_x, (
-                    constants.HEIGHT - constants.PAD_HEIGHT -
-                    constants.PADDLE_START_POSITION_OFFSET - (constants.BALL_RADIUS * 3))
+        self.rect.x = self.commanded_pos_x
+        self.rect.y = (constants.HEIGHT - constants.PAD_HEIGHT -
+                        constants.PADDLE_START_POSITION_OFFSET - (constants.BALL_RADIUS * 3))
         self.dx = rnd.choice([1, -1])
         self.dy = -1
 
@@ -185,7 +185,8 @@ class Ball(WorldObject, pygame.sprite.Sprite):
         self.v_pos = Vector2(self.commanded_pos_x,
                              (constants.HEIGHT - constants.PAD_HEIGHT -
                               constants.PADDLE_START_POSITION_OFFSET - (constants.BALL_RADIUS * 3)))
-        self.rect.center = (self.v_pos.x, self.v_pos.y)
+        self.rect.x = self.v_pos.x
+        self.rect.y = self.v_pos.y
 
         self.v_vel_unit = Vector2(1.0, 0.0)
         self.v_vel_unit = self.v_vel_unit.rotate(rnd.choice([-45.0, -135.0]))

--- a/src/brick.py
+++ b/src/brick.py
@@ -20,7 +20,7 @@ class Brick(WorldObject):
     They have a size, color, and point value
     """
 
-    def __init__(self, rect, color, value=1):
+    def __init__(self, rect, color, value=1, image=None):
         """
         Initializes a Brick object.
 
@@ -34,6 +34,7 @@ class Brick(WorldObject):
         self.rect = pygame.Rect(rect)
         self.color = color
         self.value = value
+        self.image = image
 
     def draw_wo(self, screen):
         """
@@ -42,7 +43,10 @@ class Brick(WorldObject):
         :param screen:
         :return:
         """
-        pygame.draw.rect(screen, self.color, self.rect)
+        if self.image is None:
+            pygame.draw.rect(screen, self.color, self.rect)
+        else:
+            screen.blit(self.image, self.rect)
 
     def add_collision(self):
         """

--- a/src/gameengine.py
+++ b/src/gameengine.py
@@ -88,11 +88,16 @@ class GameEngine:
                 wo.reset_position()
                 wo.speed_v = BALL_SPEED_VECTOR + (self.ps.level * BALL_SPEED_LEVEL_INCREMENT)
                 wo.speed = BALL_SPEED_SIMPLE + (self.ps.level * BALL_SPEED_LEVEL_INCREMENT)
-        # builds level in cycles of the 2 levels
-        if self.ps.level % 2 == 0:
-            Levels.build_level(self.gw, Levels.LevelName.SMASHCORE_SOLID_ROWS_1)
-        else:
+        # builds level in cycles of the 4 levels
+        if self.ps.level % 4 == 1:
             Levels.build_level(self.gw, Levels.LevelName.SMASHCORE_1)
+        if self.ps.level % 4 == 2:
+            Levels.build_level(self.gw, Levels.LevelName.SMASHCORE_SOLID_ROWS_1)
+        if self.ps.level % 4 == 3:
+            Levels.build_level(self.gw, Levels.LevelName.SMASHCORE_IMG_CHAMFER_1)
+        if self.ps.level % 4 == 0:
+            Levels.build_level(self.gw, Levels.LevelName.SMASHCORE_SOLID_ROWS_IMG_CHAMFER_1)
+
         self.fps = INITIAL_FPS_SIMPLE
         self.gs.cur_state = GameStates.READY_TO_LAUNCH
         #self.gs.ball_speed_step += BALL_SPEED_STEP_INCREMENT

--- a/src/levels.py
+++ b/src/levels.py
@@ -12,11 +12,12 @@
 
 import pygame
 from random import randrange as rnd
+from random import choice, sample
 from enum import Enum, auto
 
 from src.brick import Brick
 import constants
-
+import assets
 
 class Levels:
     """ This supplies the level building logic """
@@ -25,6 +26,8 @@ class Levels:
         """ Enum with all possible LevelNames for later construction in build_level() """
         SMASHCORE_1 = auto()
         SMASHCORE_SOLID_ROWS_1 = auto()
+        SMASHCORE_IMG_CHAMFER_1 = auto()
+        SMASHCORE_SOLID_ROWS_IMG_CHAMFER_1 = auto()
 
     def __init__(self):
         pass
@@ -60,6 +63,39 @@ class Levels:
                     for j in range(5):
                         gw.world_objects.append(Brick(pygame.Rect(10 + horizontal * i, 60 + vertical * j, 100, 50),
                                                       colors[j], values[j]))
+
+            case Levels.LevelName.SMASHCORE_IMG_CHAMFER_1:
+                for i in range(10):
+                    for j in range(4):
+                        random_brick = choice(assets.BRICK_COLORS)
+                        scaled_brick = pygame.transform.scale(random_brick, (110, 40))
+                        random_score = rnd(1, 11)
+                        gw.world_objects.append(Brick(pygame.Rect(35 + 113 * i, 120 + 40 * j, 110, 40),
+                                                      (rnd(30, 256), rnd(30, 256), rnd(30, 256)),
+                                                      random_score, image=scaled_brick))
+
+            case Levels.LevelName.SMASHCORE_SOLID_ROWS_IMG_CHAMFER_1:
+                colors = [constants.RED, constants.ORANGE, constants.GREEN, constants.YELLOW, constants.LIGHTBLUE]
+
+                # generates list of 5 unique brick colors every time the level loads
+                random_row_colors = sample(assets.BRICK_COLORS, 5)
+
+                row_colors =[]
+                for brick_color in random_row_colors:
+                    row_brick_color = pygame.transform.scale(brick_color, (100, 50))
+                    row_colors.append(row_brick_color)
+
+                values = [10, 7, 5, 3, 1]
+
+                num_columns = int((constants.WIDTH - 10) / 105)
+                horizontal = (constants.WIDTH - 10) / num_columns
+                vertical = 55
+
+                for i in range(num_columns):
+                    for j in range(5):
+                        gw.world_objects.append(Brick(pygame.Rect(10 + horizontal * i, 60 + vertical * j, 100, 50),
+                                                      colors[j], values[j], image=row_colors[j]))
+
             case _:
                 pass
 

--- a/src/paddle.py
+++ b/src/paddle.py
@@ -29,7 +29,9 @@ class Paddle(WorldObject, pygame.sprite.Sprite):
         super().__init__()
 
         # Set starting location for paddle in the bottom center of screen
-        self.rect = pygame.Rect([((constants.WIDTH/2) - (width/2)), (constants.HEIGHT - height - constants.PADDLE_START_POSITION_OFFSET), width, height])
+        self.rect = pygame.Rect([((constants.WIDTH/2) - (width/2)),
+                                 (constants.HEIGHT - (height * 2) -
+                                  constants.PADDLE_START_POSITION_OFFSET), width, height])
         self.color = color
         self.image = image
 


### PR DESCRIPTION
-modified paddle start position to lessen the gap between the ball and bring it up from the bottom of the screen
-ensured ball and paddle do not collide at start with new positioning
-created list of brick images named BRICK_COLORS in assets.py to be used for cleaner calls
-modified the brick class to accept images
-created redundancy to allow the game to load a plain colored rectangle if image fails to load
-added logic for generating bricks using non-pygame assets
-added new levels for the custom brick assets
-modified level cycle to include new levels
-changed layout of SMASHCORE_IMG_CHAMFER_1 for testing and comparison