### PR TITLE
fix initial ball speed on the start of the next level

### DIFF
--- a/src/gameengine.py
+++ b/src/gameengine.py
@@ -98,6 +98,7 @@ class GameEngine:
             if isinstance(wo, Ball):
                 wo.reset_position()
                 wo.speed_v = BALL_SPEED_VECTOR + (self.ps.level * BALL_SPEED_LEVEL_INCREMENT)
+                wo.v_vel = wo.v_vel_unit * wo.speed_v
                 wo.speed = BALL_SPEED_SIMPLE + (self.ps.level * BALL_SPEED_LEVEL_INCREMENT)
         # builds level in cycles of the 4 levels
         if self.ps.level % 4 == 1:


### PR DESCRIPTION
initial ball speed is now reset to be slightly higher (+0.10) than that of the previous level at the start of the next level instead of suddenly slowing down after the first brick collision. speed level increment can be adjusted in constants.py