### PR TITLE
Fixed Exhausted Sound Channels Crash

### DIFF
--- a/src/ball.py
+++ b/src/ball.py
@@ -86,15 +86,15 @@ class Ball(WorldObject, pygame.sprite.Sprite):
                 # ball collision wall left
                 if self.rect.centerx < self.radius:
                     self.dx = -self.dx
-                    pygame.mixer.find_channel().play(pygame.mixer.Sound(assets.LEFT_WALL_SFX))
+                    pygame.mixer.find_channel(True).play(pygame.mixer.Sound(assets.LEFT_WALL_SFX))
                 # ball collision wall right
                 if self.rect.centerx > constants.WIDTH - self.radius:
                     self.dx = -self.dx
-                    pygame.mixer.find_channel().play(pygame.mixer.Sound(assets.RIGHT_WALL_SFX))
+                    pygame.mixer.find_channel(True).play(pygame.mixer.Sound(assets.RIGHT_WALL_SFX))
                 # ball collision wall top
                 if self.rect.centery < self.radius:
                     self.dy = -self.dy
-                    pygame.mixer.find_channel().play(pygame.mixer.Sound(assets.TOP_WALL_SFX))
+                    pygame.mixer.find_channel(True).play(pygame.mixer.Sound(assets.TOP_WALL_SFX))
 
                 self.rect.x += self.speed * self.dx
                 self.rect.y += self.speed * self.dy
@@ -113,7 +113,7 @@ class Ball(WorldObject, pygame.sprite.Sprite):
                     self.primed_collision_wall_left = False
                     self.v_vel_unit.x = -self.v_vel_unit.x
                     self.v_vel.x = -self.v_vel.x
-                    pygame.mixer.find_channel().play(pygame.mixer.Sound(assets.LEFT_WALL_SFX))
+                    pygame.mixer.find_channel(True).play(pygame.mixer.Sound(assets.LEFT_WALL_SFX))
                 # reset the latch allowing collision detection since the ball has moved fully away
                 if self.v_pos.x >= self.radius:
                     self.primed_collision_wall_left = True
@@ -123,7 +123,7 @@ class Ball(WorldObject, pygame.sprite.Sprite):
                     self.primed_collision_wall_right = False
                     self.v_vel_unit.x = -self.v_vel_unit.x
                     self.v_vel.x = -self.v_vel.x
-                    pygame.mixer.find_channel().play(pygame.mixer.Sound(assets.RIGHT_WALL_SFX))
+                    pygame.mixer.find_channel(True).play(pygame.mixer.Sound(assets.RIGHT_WALL_SFX))
                 # reset the latch allowing collision detection since the ball has moved fully away
                 if self.v_pos.x <= (constants.WIDTH - self.radius):
                     self.primed_collision_wall_right = True
@@ -133,7 +133,7 @@ class Ball(WorldObject, pygame.sprite.Sprite):
                     self.primed_collision_wall_top = False
                     self.v_vel_unit.y = -self.v_vel_unit.y
                     self.v_vel.y = -self.v_vel.y
-                    pygame.mixer.find_channel().play(pygame.mixer.Sound(assets.TOP_WALL_SFX))
+                    pygame.mixer.find_channel(True).play(pygame.mixer.Sound(assets.TOP_WALL_SFX))
                 # reset the latch allowing collision detection since the ball
                 # has moved fully away
                 if self.v_pos.y >= self.radius:
@@ -241,7 +241,7 @@ class Ball(WorldObject, pygame.sprite.Sprite):
                 self.dx = -self.dx
 
             if isinstance(wo, paddle.Paddle):
-                pygame.mixer.find_channel().play(pygame.mixer.Sound(assets.PADDLE_SFX))
+                pygame.mixer.find_channel(True).play(pygame.mixer.Sound(assets.PADDLE_SFX))
 
         ##############################################################
         # determine how/which direction to bounce after collision under
@@ -286,7 +286,7 @@ class Ball(WorldObject, pygame.sprite.Sprite):
                 self.v_vel_unit = self.v_vel.normalize()
 
             if isinstance(wo, paddle.Paddle):
-                pygame.mixer.find_channel().play(pygame.mixer.Sound(assets.PADDLE_SFX))
+                pygame.mixer.find_channel(True).play(pygame.mixer.Sound(assets.PADDLE_SFX))
 
     def move_to_x(self, pos_x: int) -> None:
         """

--- a/src/brick.py
+++ b/src/brick.py
@@ -109,5 +109,5 @@ class Brick(WorldObject, pygame.sprite.Sprite):
                                                self.rect.height * constants.EFFECT_BRICK_IMAGE_DESTROY_INFLATION),
                                            self.color, constants.EFFECT_BRICK_IMAGE_DESTROY_FADE, images=assets.BRICK_ANIMATION))
 
-        pygame.mixer.find_channel().play(pygame.mixer.Sound(assets.BRICK_SFX))
+        pygame.mixer.find_channel(True).play(pygame.mixer.Sound(assets.BRICK_SFX))
 


### PR DESCRIPTION
used force=True in find_channel() so that we can't get back None, preventing this crash with too many successive playing sound effects (just kills off oldest sound)