### PR TITLE
Renamed click to play buttons

### DIFF
--- a/src/gameengine.py
+++ b/src/gameengine.py
@@ -579,11 +579,11 @@ class GameEngine:
                 if (event.type == pygame.MOUSEBUTTONDOWN and
                         ((self.gs.cur_state == GameState.GameStateName.PAUSED) or
                          (self.gs.cur_state == GameState.GameStateName.GAME_OVER))):
-                    if self.restart_game_button and self.restart_game_button.collidepoint(event.pos):
+                    if self.restart_game_button.collidepoint(event.pos):
                         self.reset_game()
-                    if self.quit_game_button and self.quit_game_button.collidepoint(event.pos):
+                    if self.quit_game_button.collidepoint(event.pos):
                         self.clean_shutdown()
-                    if self.main_menu_button and self.main_menu_button.collidepoint(event.pos):
+                    if self.main_menu_button.collidepoint(event.pos):
                         self.gs.cur_state = GameState.GameStateName.MENU_SCREEN
 
                 if (event.type == pygame.MOUSEBUTTONDOWN and

--- a/src/userinterface.py
+++ b/src/userinterface.py
@@ -445,7 +445,7 @@ class UserInterface:
             self.surface.blit(brick['image'], brick['rect'])
 
         # Draw Click to Play CLASSIC button
-        start_text = self.font_menu_main.render("Click to Play CLASSIC", True, constants.BLACK)
+        start_text = self.font_menu_main.render("PLAY CLASSIC", True, constants.BLACK)
         button_width = start_text.get_width() + 120
         button_height = start_text.get_height() + 60
 
@@ -455,7 +455,7 @@ class UserInterface:
                                                   constants.GREEN, constants.DARK_GREEN)
 
         # Draw Click to Play MODERN button
-        start_text = self.font_menu_main.render("Click to Play MODERN", True, constants.BLACK)
+        start_text = self.font_menu_main.render("PLAY MODERN", True, constants.BLACK)
         button_width = start_text.get_width() + 120
         button_height = start_text.get_height() + 60
 
@@ -513,7 +513,7 @@ class UserInterface:
             "Breaking all of the bricks clears the level.",
             "",
             "ESC to pause.",
-            "CTRL + D for dev stats."
+            "CTRL + D for dev stats.",
             "CTRL + - to decrease overall volume.",
             "CTRL + = to increase overall volume."
         ]


### PR DESCRIPTION
I just renamed the 'Click to Play CLASSIC/MODERN' to just 'PLAY CLASSIC/MODERN' to keep it consistent with the other buttons. (its the only button with the action word).