### PR TITLE
trigger larger screen shake when last brick destroyed, with 'level cleared' msg; also fixed small sound mute bug

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -83,3 +83,6 @@ EFFECT_BRICK_IMAGE_DESTROY_FADE = False # fade the destroyed Brick?
 
 EFFECT_POWER_UP_DURATION = 2000 # lifetime of fading power-up image, in ms
 EFFECT_POWER_UP_DROP_ACC_Y = 0.00025 # y-comp of power-up image dropping acceleration
+
+LEVEL_CLEARED_DURATION = 3500 # how long to display the fading 'Level Cleared' message
+LEVEL_CLEARED_SHAKE_MAGNITUDE = 40 # how much of a final shake to trigger

--- a/src/gameengine.py
+++ b/src/gameengine.py
@@ -9,6 +9,7 @@
     Module Description: This brings together the various modules that make up the game (GameWorld,
                         GameState, UI, etc.) and runs the main game loop.
 """
+
 from sys import exit
 import pygame
 
@@ -27,7 +28,8 @@ from constants import (WIDTH, HEIGHT, INITIAL_FPS_SIMPLE, GAME_NAME,
                        PADDLE_IMPULSE_INCREMENT, WORLD_GRAVITY_ACC_INCREMENT,
                        BALL_SPEED_STEP_INCREMENT, MAX_FPS_VECTOR, SCORE_INITIALS_MAX,
                        MUSIC_VOLUME_STEP, SLIDER_WIDTH, KNOB_RADIUS, LIGHT_GRAY, SFX_VOLUME_STEP, CLOSE_TO_ZERO,
-                       SHAKE_OFFSET_BASE, SHAKE_STRENGTH_THRESHOLD)
+                       SHAKE_OFFSET_BASE, SHAKE_STRENGTH_THRESHOLD, LEVEL_CLEARED_DURATION,
+                       LEVEL_CLEARED_SHAKE_MAGNITUDE)
 from levels import Levels
 from gameworld import GameWorld
 from userinterface import UserInterface
@@ -49,6 +51,7 @@ class GameEngine:
         :param gset: GameSettings
         :param ui: UserInterface
         """
+
         self.prev_state = None
         self.quit_game_button = None
         self.restart_game_button = None
@@ -317,15 +320,17 @@ class GameEngine:
                     if event.type == pygame.MOUSEBUTTONDOWN:
                         if self.ui.vol_bgm_btn_rect.collidepoint(event.pos):
                             self.gset.bgm_sounds = not self.gset.bgm_sounds
-                            if not self.gset.bgm_sounds and abs(self.gset.music_volume) < CLOSE_TO_ZERO:
-                                self.gset.bgm_sounds = True
+                            if self.gset.bgm_sounds:
                                 self.gset.music_volume = MUSIC_VOLUME_STEP
-                                pygame.mixer.music.set_volume(self.gset.music_volume)
+                            else:
+                                self.gset.music_volume = 0.0
+                            pygame.mixer.music.set_volume(self.gset.music_volume)
                         elif self.ui.vol_sfx_btn_rect.collidepoint(event.pos):
                             self.gset.sfx_sounds = not self.gset.sfx_sounds
-                            if not self.gset.sfx_sounds and abs(self.gset.sfx_volume) < CLOSE_TO_ZERO:
-                                self.gset.sfx_sounds = True
+                            if self.gset.sfx_sounds:
                                 self.gset.sfx_volume = SFX_VOLUME_STEP
+                            else:
+                                self.gset.sfx_volume = 0.0
                         elif self.ui.back_button_rect.collidepoint(event.pos):
                             self.gs.cur_state = GameState.GameStateName.MENU_SCREEN
                         elif self.ui.knob_bg_rect.collidepoint(event.pos):
@@ -438,7 +443,14 @@ class GameEngine:
 
                 # set latch to ignore ball below screen once all Bricks cleared (mostly so that Animations
                 # can complete without penalty if the player stops reflecting the Ball)
-                if not any(isinstance(wo, Brick) for wo in self.gw.world_objects):
+                if (not self.gs.level_cleared) and (not any(isinstance(wo, Brick) for wo in self.gw.world_objects)):
+                    # add a level-cleared animation
+                    self.gw.world_objects.append(Animation(LEVEL_CLEARED_DURATION,
+                                                           (0, 0, WIDTH, HEIGHT),
+                                                           BLACK, fade=True, is_lvl_clr_msg=True))
+                    # trigger the big, final brick cleared shake
+                    utils.start_shake(self.gs, LEVEL_CLEARED_SHAKE_MAGNITUDE)
+
                     self.gs.level_cleared = True
 
                 # don't advance to the next level until all bricks are gone AND animations have completed

--- a/src/gamestate.py
+++ b/src/gamestate.py
@@ -53,9 +53,16 @@ class GameState:
 
         self.level_cleared: bool = False
 
+        # shake effect config
         self.shake_screen_brick: bool = False
-        self.shake_offset_x = 1
-        self.shake_offset_y = 1
+        self.shake_strength: int = 0
+
+        # these are used to index into the following lists on subsequent calls to utils.get_shaking_offset() to get the shake offset
+        self.shake_off_index_x = 0
+        self.shake_off_index_y = 0
+        # these are the shake offset values to sequence through -- better to hard-code these up front, rather than trying to calculate
+        self.shake_offsets_x = [5, 5, 3, -4, -1, -3, -2, -2, 3, 4, 1, 2, 0, -1, -2, -3, -2, 1, 0, 5, 2, 1, 0, -1, -2, -1, 0, 0]
+        self.shake_offsets_y = [5, -5, 0, -3, -3, 1, 1, 0, 4, -2, 1, -2, 1, 1, 2, 3, -2, -1, 4, 2, 2, -1, 2, 3, 2, -1, 0, 0]
 
         self.paddle_pos_x: int = 0  # used at READY_TO_LAUNCH to keep ball on paddle
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -34,42 +34,37 @@ def calculate_timing_averages(fps: float, loop_time: float) -> tuple:
     loop_time_q.appendleft(loop_time)
     return statistics.mean(fps_q), statistics.mean(loop_time_q)
 
-def start_shake(gs: GameState, initial_offset: int) -> None:
+def start_shake(gs: GameState, strength: int) -> None:
     """
     This begins the screen shaking effect.
 
     :param gs: GameState
-    :param initial_offset: the initial offset in pixels to use for screen 'shaking'
+    :param strength: the initial strength to use for screen 'shaking'
     :return:
     """
 
     gs.shake_screen_brick = True
-    gs.shake_offset_x = initial_offset
-    gs.shake_offset_y = initial_offset
+    gs.shake_strength = strength
+    # reset the indices into the lists with the offset shift values
+    gs.shake_off_index_x = gs.shake_off_index_y = 0
 
 def get_shaking_offset(gs: GameState) -> tuple[int, int]:
     """
-    This very simply calculates a kind of oscillation in pixels around the base
-    (0, 0) offset.
+    This iterates over the GameState.shake_offsets_x/y lists to get decent offset values.
 
     :param gs: GameState
     :return: the offset in pixels
     """
 
     if gs.shake_screen_brick:
-        if gs.shake_offset_x > 0:
-            shift_x = (abs(2 * gs.shake_offset_x) - 1) * -1
-            shift_y = (abs(2 * gs.shake_offset_y) - 1) * -1
-        else:
-            shift_x = (abs(2 * gs.shake_offset_x) - 1) * 1
-            shift_y = (abs(2 * gs.shake_offset_y) - 1) * 1
-
-        gs.shake_offset_x += shift_x
-        gs.shake_offset_y += shift_y
-
-        if (abs(gs.shake_offset_x) < 1) and (abs(gs.shake_offset_y) < 1):
+        if ((gs.shake_off_index_x + 1) > len(gs.shake_offsets_x)) or ((gs.shake_off_index_y + 1) > len(gs.shake_offsets_y)):
             gs.shake_screen_brick = False
-
-        return gs.shake_offset_x, gs.shake_offset_y
+            return 0, 0
+        else:
+            off_x = gs.shake_offsets_x[gs.shake_off_index_x] * gs.shake_strength / 4
+            off_y = gs.shake_offsets_y[gs.shake_off_index_y] * gs.shake_strength / 4
+            gs.shake_off_index_x += 1
+            gs.shake_off_index_y += 1
+            return off_x, off_y
     else:
         return 0, 0

--- a/tests/test_gameengine_gamestate.py
+++ b/tests/test_gameengine_gamestate.py
@@ -15,6 +15,7 @@ import pytest
 
 import constants
 from unittest import mock
+from unittest.mock import MagicMock
 
 import playerstate
 from gameengine import GameEngine
@@ -43,16 +44,19 @@ def mock_pygame():
          mock.patch("pygame.mouse.get_pos", return_value=[4]) as mock_mouse_pos, \
          mock.patch("pygame.time.get_ticks", return_value=123456) as mock_get_ticks, \
          mock.patch("pygame.display.set_mode") as mock_set_mode, \
-         mock.patch("pygame.draw.line") as mock_draw_line:
+         mock.patch("pygame.draw.line") as mock_draw_line, \
+         mock.patch("pygame.font") as mock_font:
 
         # Setup return values if needed
         mock_set_mode.return_value = mock.MagicMock(name="screen")
+        mock_font.return_value.render = MagicMock(return_value=pygame.Surface)
 
         yield {
             "mixer_init": mock_mixer_init,
             "mixer.music": mock_mixer_music,
             "set_mode": mock_set_mode,
             "get_ticks": mock_get_ticks,
+            "font": mock_font,
             "mouse_set_visible": mock_mouse_set_visible,
             "mouse_mock_position": mock_mouse_pos,
             "draw_line": mock_draw_line
@@ -325,7 +329,7 @@ def test_gamestate_ready_to_launch_initialization(mock_levels, starting_ge):
 @mock.patch("levels.Levels")
 def test_gamestate_playing(mock_levels, starting_ge):
     """
-    Test GameState PLAYING, no bricks indicating level is over
+    Test GameState PLAYING, no bricks and level_cleared == True indicating level is over
     Test draw_world_and_status was called once
     Test draw_game_intro was not called
     Test that last_mouse_pos_x changed to 4
@@ -334,6 +338,7 @@ def test_gamestate_playing(mock_levels, starting_ge):
     """
     ge, mock_pygame = starting_ge
     ge.gs.cur_state = GameState.GameStateName.PLAYING
+    ge.gs.level_cleared = True
     ge.gs.last_mouse_pos_x = 5
     ge.ps.level = 1
 


### PR DESCRIPTION
trigger larger screen shake when last brick destroyed; added a 'Level Cleared!' fading message that pops up at the successful end of the level (did that so that the shake would be more noticeable); freezing the ball below the screen IF cleared level; fixed a small sound bug with the effects mute button not working in game; changed the method for determining the shake screen offset, so that it's rougher and seemingly random (was too smooth before)